### PR TITLE
Remove pointer decrement

### DIFF
--- a/src/fuse_cpp_ramfs.cpp
+++ b/src/fuse_cpp_ramfs.cpp
@@ -675,7 +675,7 @@ void FuseRamFs::FuseReadDir(fuse_req_t req, fuse_ino_t ino, size_t size,
                                         ++ctx->cookie);
         if (bytesAdded > bufSize) {
             // Oops. There wasn't enough space for that last item. Back up and exit.
-            --(ctx->it);
+            // --(ctx->it);
             bytesAdded = oldSize;
             break;
         } else {


### PR DESCRIPTION
Removed line which decremented pointer when buffer is full, which caused a double-write upon second call.